### PR TITLE
Complete templating option for VeriMove to BIP

### DIFF
--- a/src/BIPTemplates/BIPComplete.ejs
+++ b/src/BIPTemplates/BIPComplete.ejs
@@ -1,0 +1,6 @@
+<%- classStart %>
+<%- ports %>
+<%- states %>
+<%- initialAction %>
+<%- transitions %>
+<%- classEnd %>

--- a/src/BIPTemplates/BIPPorts.ejs
+++ b/src/BIPTemplates/BIPPorts.ejs
@@ -1,0 +1,3 @@
+
+<%for(var i = 0; i < transitions.length; i += 1) {%>
+export port syncPort <%-transitions[i].name%> <% } %>

--- a/src/BIPTemplates/BIPStates.ejs
+++ b/src/BIPTemplates/BIPStates.ejs
@@ -1,0 +1,1 @@
+place <%for(var i = 0; i < states.length; i += 1) {%> <%-states[i]%><%if (i < states.length-1) {%>,<% } %> <% } %>

--- a/src/BIPTemplates/BIPTransitions.ejs
+++ b/src/BIPTemplates/BIPTransitions.ejs
@@ -1,0 +1,3 @@
+<%for(var i = 0;i < transitions.length; i += 1) {%>
+on <%- transitions[i].name %> from <%- transitions[i].src %> to <%- transitions[i].dst %>
+<% } %>

--- a/src/BIPTemplates/contractBIPEnd.ejs
+++ b/src/BIPTemplates/contractBIPEnd.ejs
@@ -1,0 +1,15 @@
+end
+
+compound type globModel
+
+  component <%- name %> BAUC
+
+  <%for(var i = 0;i < transitions.length; i += 1) {%>
+  connector SINGLE BAUC_<%- transitions[i].name %> ( BAUC.<%- transitions[i].name %> )
+  <% } %>
+
+  end
+
+  component globModel Root
+
+  end

--- a/src/BIPTemplates/contractBIPStart.ejs
+++ b/src/BIPTemplates/contractBIPStart.ejs
@@ -1,0 +1,9 @@
+model <%- name %>Model
+
+	port type syncPort
+
+  connector type SINGLE(syncPort p1)
+    define p1
+  end
+
+atomic type <%- name %>

--- a/src/BIPTemplates/ejsCache.ejs
+++ b/src/BIPTemplates/ejsCache.ejs
@@ -1,0 +1,39 @@
+define([
+    'common/util/ejs',
+    'text!./contractBIPStart.ejs',
+    'text!./contractBIPEnd.ejs',
+    'text!./BIPPorts.ejs',
+    'text!./BIPStates.ejs',
+    'text!./initialBIPAction.ejs',
+    'text!./BIPTransitions.ejs',
+    'text!./BIPComplete.ejs'
+], function (ejs,
+             classStart,
+             classEnd,
+             ports,
+             states,
+             initialAction,
+             transitions,
+             complete
+             ) {
+
+    return {
+        contractType: {
+            bipStart: classStart,
+            bipEnd: classEnd,
+            bipPorts: ports,
+            bipStates: states,
+            bipInitialAction: initialAction,
+            bipTransitions: transitions,
+            complete: ejs.render(complete, {
+                classStart: classStart,
+                ports: ports,
+                states: states,
+                initialAction: initialAction,
+                transitions: transitions,
+                classEnd: classEnd
+            })
+        }
+    };
+});
+

--- a/src/BIPTemplates/initialBIPAction.ejs
+++ b/src/BIPTemplates/initialBIPAction.ejs
@@ -1,0 +1,1 @@
+initial to <%- initialState %>


### PR DESCRIPTION
There were no changes that needed to be made from the original VeriSolid implementation. The following templates are mapped to the augment model. The key values in augment model are as follows:

``` 
{
      'name': model['name'],
      'states': augmentedStates,
      'transitions': augmentedTransitions,
      'initialState': model['initialState'],
      'finalStates': model['finalStates']
};
```

The format of the BIP template is as follows: 

```
         atom type Contract()
∀v ∈ V : data type(v) name(v)
∀t ∈ T : export port synPor t-name()
              places s0, . . . , s|S|−1
              initial to s0
∀t ∈ T : on t-name from t-from to t-to
              provided (gt) do {at}
         end
```

Resolves #12 