### PR TITLE
Add licensing information for dependencies

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -599,7 +599,7 @@ esprima@4.0.1
 
 
 // The packages under the Apache 2.0 License follow:
-Copyright 2019 material-motion
+Copyright 2019 material-motion // indefinite-observable-js
 
 detect-libc@1.0.3
 tunnel-agent@0.6.0


### PR DESCRIPTION
Added copyright information for dependencies. I've been told that once we cover all our direct dependencies within our license files, then the dependencies of our dependencies are covered in their license files.

I did notice however, the dependencies repos never usually had more than 1 license copyright. The only time there were more than 1 was when specific code bits from other repos were used. But to be safe I added all the dependencies copyrights into our file.

Also, added a change to the eslint rules to avoid all bundle.js files.